### PR TITLE
Add `spanish` translation and minor fixes

### DIFF
--- a/src/enum/static-routes.ts
+++ b/src/enum/static-routes.ts
@@ -7,4 +7,5 @@ export const StaticRoutes = {
   RESET_PASSWORD: "/reset-password",
   CONSENT: "/consent",
   "2FA": "/2fa",
+  NOT_FOUND: "/not-found"
 };

--- a/src/public/components/get-code.js
+++ b/src/public/components/get-code.js
@@ -40,7 +40,7 @@ export default function GetCode() {
                 if (response.responseJSON.additionalInfo && response.status === 400) {
                     return onFieldError({ response });
                 }
-                onSubmitError({ errorText: i18next.t("error.inavlid-login") });
+                onSubmitError({ errorText: i18next.t("error.invalid-login") });
             })
             .always(function () {
                 setSubmitting(false);

--- a/src/public/components/login.js
+++ b/src/public/components/login.js
@@ -97,7 +97,7 @@ export default function Login() {
         if (response.status === 400 && response.responseJSON.additionalInfo) {
           return onFieldError({ response });
         }
-        onSubmitError({ errorText: i18next.t("error.inavlid-login") });
+        onSubmitError({ errorText: i18next.t("error.invalid-login") });
       })
       .always(function () {
         setSubmitting(false);

--- a/src/public/components/not-found.js
+++ b/src/public/components/not-found.js
@@ -1,5 +1,5 @@
 export default function NotFound() {
     return (
-        <div>404 | This page could not be found</div>
+        <div>404 | {i18next.t("message.page-not-found")}</div>
     )
 }

--- a/src/public/languages/en.json
+++ b/src/public/languages/en.json
@@ -20,7 +20,7 @@
   "error.too-many-retries": "Too Many Retries",
   "error.too-many-requests": "Too Many Requests",
   "error.account-not-verified": "Account not verified",
-  "error.inavlid-login": "Invalid Login",
+  "error.invalid-login": "Invalid Login",
   "error.bad-email-domain": "Bad email domain",
   "error.duplicate-account": "Account already exists",
   "error.signup-error": "Signup error",

--- a/src/public/languages/en.json
+++ b/src/public/languages/en.json
@@ -33,6 +33,7 @@
   "message.verification-instructions": "A verification code was sent to your email address.",
   "message.recover-instructions": "Enter your email address to recover your account.",
   "message.reset-password-instructions": "A verification code was sent to your email address.",
+  "message.page-not-found": "This page could not be found",
 
   "button.login": "Login",
   "button.signup": "Create Account",

--- a/src/public/languages/es.json
+++ b/src/public/languages/es.json
@@ -1,0 +1,77 @@
+{
+  "title.login": "Inicia sesión en",
+  "title.signup": "Crear una cuenta",
+  "title.2fa": "Verificación en dos pasos",
+  "title.consent": "Consentimiento requerido",
+  "title.get-code": "Verifica Tu Identidad",
+  "title.reset-password": "Reestablece tu contraseña",
+  "title.verify-account": "Verifica Tu Cuenta",
+  "title.verify-your-identity": "Verifica Tu Identidad",
+
+  "heading.login": "Inicia sesión en",
+  "heading.signup": "Crear una cuenta",
+  "heading.2fa": "Verificación en dos pasos",
+  "heading.consent": "Consentimiento requerido",
+  "heading.get-code": "Verifica Tu Identidad",
+  "heading.reset-password": "Reestablece tu contraseña",
+  "heading.verify-account": "Verifica Tu Cuenta",
+  "heading.verify-your-identity": "Verifica Tu Identidad",
+
+  "error.too-many-retries": "Demasiados Reintentos",
+  "error.too-many-requests": "Demasiadas Peticiones",
+  "error.account-not-verified": "Cuenta no verificada",
+  "error.invalid-login": "Inicio de sesión inválido",
+  "error.bad-email-domain": "Dominio de e-mail erróneo",
+  "error.duplicate-account": "La cuenta ya existe",
+  "error.signup-error": "Error en el registro",
+  "error.invalid-field": "{{field_name}} inválido/a",
+  "error.invalid-code": "Código inválido",
+
+  "message.enter-login-code": "Para iniciar sesión, introduce el código de verificación enviado a tu dirección de correo electrónico.",
+  "message.consent": "{{app_name}} quiere acceder a tu cuenta. Si aceptas los términos, {{app_name}} podrá:",
+  "message.consent-warning": "Antes de consentir, asegúrate de que confías en esta aplicación ya que podrías estar compartiendo información sensible.",
+  "message.verification-instructions": "Un código de verificación ha sido enviado a tu dirección de correo electrónico.",
+  "message.recover-instructions": "Introduce tu dirección de correo electrónico para recuperar tu cuenta.",
+  "message.reset-password-instructions": "Un código de verificación ha sido enviado a tu dirección de correo electrónico.",
+
+  "button.login": "Iniciar sesión",
+  "button.signup": "Crear una cuenta",
+  "button.submit": "Enviar",
+  "button.consent": "Consentir",
+  "button.refuse": "Denegar",
+  "button.get-code": "Obtener código",
+  "button.change-password": "Cambiar contraseña",
+  "button.verify": "Verificar",
+
+  "field.label.username": "Usuario",
+  "field.placeholder.username": "tu_usuario",
+
+  "field.label.invite-code": "Código de invitación",
+  "field.placeholder.invite-code": "TU-CÓDIGO-DE-INVITACIÓN",
+
+  "field.label.verification-code": "Código de verificación",
+  "field.placeholder.verification-code": "000000",
+
+  "field.label.first-name": "Nombre",
+  "field.placeholder.first-name": "Tu Nombre",
+
+  "field.label.last-name": "Apellidos",
+  "field.placeholder.last-name": "Tus Apellidos",
+
+  "field.label.email": "E-mail",
+  "field.placeholder.email": "tu@email.com",
+
+  "field.label.username-or-email": "Usuario o e-mail",
+  "field.placeholder.username-or-email": "tu_usuario",
+
+  "field.label.password": "Contraseña",
+  "field.placeholder.password": "********",
+
+  "field.label.new-password": "Nueva contraseña",
+  "field.placeholder.new-password": "********",
+
+  "link.create-account": "Crear cuenta",
+  "link.forgot-password": "¿Olvidaste tu contraseña?",
+  "link.login": "¿Tienes una cuenta? Inicia sesión",
+  "link.login-minimal": "Iniciar sesión"
+}

--- a/src/public/languages/es.json
+++ b/src/public/languages/es.json
@@ -33,6 +33,7 @@
   "message.verification-instructions": "Un código de verificación ha sido enviado a tu dirección de correo electrónico.",
   "message.recover-instructions": "Introduce tu dirección de correo electrónico para recuperar tu cuenta.",
   "message.reset-password-instructions": "Un código de verificación ha sido enviado a tu dirección de correo electrónico.",
+  "message.page-not-found": "No se pudo encontrar esta página",
 
   "button.login": "Iniciar sesión",
   "button.signup": "Crear una cuenta",

--- a/src/public/languages/fr.json
+++ b/src/public/languages/fr.json
@@ -20,7 +20,7 @@
   "error.too-many-retries": "Trop de tentatives",
   "error.too-many-requests": "Trop de demandes",
   "error.account-not-verified": "Compte non vérifié",
-  "error.inavlid-login": "Identifiant invalide",
+  "error.invalid-login": "Identifiant invalide",
   "error.bad-email-domain": "Mauvais domaine de messagerie",
   "error.duplicate-account": "Le compte existe déjà",
   "error.signup-error": "Erreur d'inscription",

--- a/src/public/languages/fr.json
+++ b/src/public/languages/fr.json
@@ -33,6 +33,7 @@
   "message.verification-instructions": "Un code de vérification a été envoyé à votre adresse e-mail.",
   "message.recover-instructions": "Entrez votre adresse e-mail pour récupérer votre compte.",
   "message.reset-password-instructions": "Un code de vérification a été envoyé à votre adresse e-mail.",
+  "message.page-not-found": "Cette page est introuvable",
 
   "button.login": "Se connecter",
   "button.signup": "Créer un compte",

--- a/src/public/languages/ta.json
+++ b/src/public/languages/ta.json
@@ -20,7 +20,7 @@
     "error.too-many-retries": "மிக அதிகமான முயற்சிகள்",
     "error.too-many-requests": "மிக அதிகமான கோரிக்கைகள்",
     "error.account-not-verified": "கணக்கு சரிபார்க்கப்படவில்லை",
-    "error.inavlid-login": "தவறான புகுபதிவு",
+    "error.invalid-login": "தவறான புகுபதிவு",
     "error.bad-email-domain": "தவறான மின்னஞ்சல் டொமைன்",
     "error.duplicate-account": "கணக்கு ஏற்கனவே உள்ளது",
     "error.signup-error": "பதிவு பிழை",

--- a/src/public/languages/ta.json
+++ b/src/public/languages/ta.json
@@ -1,78 +1,78 @@
 {
-    "title.login": "உள்நுழைக",
-    "title.signup": "பதிவு செய்க",
-    "title.2fa": "இரண்டு-படி சரிபார்ப்பு",
-    "title.consent": "ஒப்புதலை வழங்கவும்",
-    "title.get-code": "அடையாளத்தை நிரூபிக்கவும்",
-    "title.reset-password": "கடவுச்சொல்லை மீட்டமைக்க",
-    "title.verify-account": "கணக்கை நிரூபிக்கவும்",
-    "title.verify-your-identity": "அடையாளத்தை நிரூபிக்கவும்",
-  
-    "heading.login": "உள்நுழைக",
-    "heading.signup": "பதிவு செய்க",
-    "heading.2fa": "இரண்டு-படி சரிபார்ப்பு",
-    "heading.consent": "ஒப்புதலை வழங்கவும்",
-    "heading.get-code": "அடையாளத்தை நிரூபிக்கவும்",
-    "heading.reset-password": "கடவுச்சொல்லை மீட்டமைக்க",
-    "heading.verify-account": "கணக்கை நிரூபிக்கவும்",
-    "heading.verify-your-identity": "அடையாளத்தை நிரூபிக்கவும்",
-  
-    "error.too-many-retries": "மிக அதிகமான முயற்சிகள்",
-    "error.too-many-requests": "மிக அதிகமான கோரிக்கைகள்",
-    "error.account-not-verified": "கணக்கு சரிபார்க்கப்படவில்லை",
-    "error.invalid-login": "தவறான புகுபதிவு",
-    "error.bad-email-domain": "தவறான மின்னஞ்சல் டொமைன்",
-    "error.duplicate-account": "கணக்கு ஏற்கனவே உள்ளது",
-    "error.signup-error": "பதிவு பிழை",
-    "error.invalid-field": "தவறான {{field_name}}",
-    "error.invalid-code": "தவறான குறியீடு",
-  
-    "message.enter-login-code": "உள்நுழைய, உங்கள் மின்னஞ்சல் முகவரிக்கு அனுப்பப்பட்ட சரிபார்ப்புக் குறியீட்டை உள்ளிடவும்.",
-    "message.consent": "{{app_name}} உங்கள் கணக்கைப் பயன்படுத்த விரும்புகிறது. இதற்கு நீங்கள் ஒப்புக்கொண்டால், {{app_name}} பின்வருவனவற்றைச் செய்ய முடியும்:",
-    "message.consent-warning": "நீங்கள் ஒப்புக்கொள்வதற்கு முன், முக்கியமான தகவலைப் பகிர்வதால், இந்தப் பயன்பாட்டை நம்புகிறீர்கள் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்.",
-    "message.verification-instructions": "உங்கள் மின்னஞ்சல் முகவரிக்கு சரிபார்ப்புக் குறியீடு அனுப்பப்பட்டது.",
-    "message.recover-instructions": "உங்கள் கணக்கை மீட்டெடுக்க உங்கள் மின்னஞ்சல் முகவரியை உள்ளிடவும்.",
-    "message.reset-password-instructions": "உங்கள் மின்னஞ்சல் முகவரிக்கு சரிபார்ப்புக் குறியீடு அனுப்பப்பட்டது.",
-  
-    "button.login": "உள்நுழைக",
-    "button.signup": "கணக்கை துவங்குங்கள்",
-    "button.submit": "சமர்ப்பிக்க",
-    "button.consent": "சம்மதம்",
-    "button.refuse": "மறுக்கவும்",
-    "button.get-code": "குறியீடு பெற",
-    "button.change-password": "கடவுச்சொல்லை மாற்று",
-    "button.verify": "சரிபார்க்கவும்",
-  
-    "field.label.username": "கணக்கு கைப்பிடி",
-    "field.placeholder.username": "கணக்கு_கைப்பிடி",
-  
-    "field.label.invite-code": "அழைப்பு குறியீடு",
-    "field.placeholder.invite-code": "உங்கள்-அழைப்புக்-குறியீடு",
-  
-    "field.label.verification-code": "சரிபார்ப்பு குறியீடு",
-    "field.placeholder.verification-code": "000000",
-  
-    "field.label.first-name": "முதல் பெயர்",
-    "field.placeholder.first-name": "உங்களுடைய முதல் பெயர்",
-  
-    "field.label.last-name": "கடைசி பெயர்",
-    "field.placeholder.last-name": "உங்களுடைய கடைசி பெயர்",
-  
-    "field.label.email": "மின்னஞ்சல்",
-    "field.placeholder.email": "உங்களுடைய@மின்னஞ்சல்.com",
-  
-    "field.label.username-or-email": "கணக்கு கைப்பிடி அல்லது மின்னஞ்சல்",
-    "field.placeholder.username-or-email": "கணக்கு_கைப்பிடி",
-  
-    "field.label.password": "கடவுச்சொல்",
-    "field.placeholder.password": "********",
-  
-    "field.label.new-password": "புதிய கடவுச்சொல்",
-    "field.placeholder.new-password": "********",
-  
-    "link.create-account": "கணக்கை துவங்குங்கள்",
-    "link.forgot-password": "கடவுச்சொல்லை மறந்துவிட்டீர்களா?",
-    "link.login": "கணக்கு உள்ளதா? உள்நுழைய",
-    "link.login-minimal": "உள்நுழைய"
-  }
-  
+  "title.login": "உள்நுழைக",
+  "title.signup": "பதிவு செய்க",
+  "title.2fa": "இரண்டு-படி சரிபார்ப்பு",
+  "title.consent": "ஒப்புதலை வழங்கவும்",
+  "title.get-code": "அடையாளத்தை நிரூபிக்கவும்",
+  "title.reset-password": "கடவுச்சொல்லை மீட்டமைக்க",
+  "title.verify-account": "கணக்கை நிரூபிக்கவும்",
+  "title.verify-your-identity": "அடையாளத்தை நிரூபிக்கவும்",
+
+  "heading.login": "உள்நுழைக",
+  "heading.signup": "பதிவு செய்க",
+  "heading.2fa": "இரண்டு-படி சரிபார்ப்பு",
+  "heading.consent": "ஒப்புதலை வழங்கவும்",
+  "heading.get-code": "அடையாளத்தை நிரூபிக்கவும்",
+  "heading.reset-password": "கடவுச்சொல்லை மீட்டமைக்க",
+  "heading.verify-account": "கணக்கை நிரூபிக்கவும்",
+  "heading.verify-your-identity": "அடையாளத்தை நிரூபிக்கவும்",
+
+  "error.too-many-retries": "மிக அதிகமான முயற்சிகள்",
+  "error.too-many-requests": "மிக அதிகமான கோரிக்கைகள்",
+  "error.account-not-verified": "கணக்கு சரிபார்க்கப்படவில்லை",
+  "error.invalid-login": "தவறான புகுபதிவு",
+  "error.bad-email-domain": "தவறான மின்னஞ்சல் டொமைன்",
+  "error.duplicate-account": "கணக்கு ஏற்கனவே உள்ளது",
+  "error.signup-error": "பதிவு பிழை",
+  "error.invalid-field": "தவறான {{field_name}}",
+  "error.invalid-code": "தவறான குறியீடு",
+
+  "message.enter-login-code": "உள்நுழைய, உங்கள் மின்னஞ்சல் முகவரிக்கு அனுப்பப்பட்ட சரிபார்ப்புக் குறியீட்டை உள்ளிடவும்.",
+  "message.consent": "{{app_name}} உங்கள் கணக்கைப் பயன்படுத்த விரும்புகிறது. இதற்கு நீங்கள் ஒப்புக்கொண்டால், {{app_name}} பின்வருவனவற்றைச் செய்ய முடியும்:",
+  "message.consent-warning": "நீங்கள் ஒப்புக்கொள்வதற்கு முன், முக்கியமான தகவலைப் பகிர்வதால், இந்தப் பயன்பாட்டை நம்புகிறீர்கள் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்.",
+  "message.verification-instructions": "உங்கள் மின்னஞ்சல் முகவரிக்கு சரிபார்ப்புக் குறியீடு அனுப்பப்பட்டது.",
+  "message.recover-instructions": "உங்கள் கணக்கை மீட்டெடுக்க உங்கள் மின்னஞ்சல் முகவரியை உள்ளிடவும்.",
+  "message.reset-password-instructions": "உங்கள் மின்னஞ்சல் முகவரிக்கு சரிபார்ப்புக் குறியீடு அனுப்பப்பட்டது.",
+  "message.page-not-found": "இந்தப் பக்கத்தைக் காண முடியவில்லை",
+
+  "button.login": "உள்நுழைக",
+  "button.signup": "கணக்கை துவங்குங்கள்",
+  "button.submit": "சமர்ப்பிக்க",
+  "button.consent": "சம்மதம்",
+  "button.refuse": "மறுக்கவும்",
+  "button.get-code": "குறியீடு பெற",
+  "button.change-password": "கடவுச்சொல்லை மாற்று",
+  "button.verify": "சரிபார்க்கவும்",
+
+  "field.label.username": "கணக்கு கைப்பிடி",
+  "field.placeholder.username": "கணக்கு_கைப்பிடி",
+
+  "field.label.invite-code": "அழைப்பு குறியீடு",
+  "field.placeholder.invite-code": "உங்கள்-அழைப்புக்-குறியீடு",
+
+  "field.label.verification-code": "சரிபார்ப்பு குறியீடு",
+  "field.placeholder.verification-code": "000000",
+
+  "field.label.first-name": "முதல் பெயர்",
+  "field.placeholder.first-name": "உங்களுடைய முதல் பெயர்",
+
+  "field.label.last-name": "கடைசி பெயர்",
+  "field.placeholder.last-name": "உங்களுடைய கடைசி பெயர்",
+
+  "field.label.email": "மின்னஞ்சல்",
+  "field.placeholder.email": "உங்களுடைய@மின்னஞ்சல்.com",
+
+  "field.label.username-or-email": "கணக்கு கைப்பிடி அல்லது மின்னஞ்சல்",
+  "field.placeholder.username-or-email": "கணக்கு_கைப்பிடி",
+
+  "field.label.password": "கடவுச்சொல்",
+  "field.placeholder.password": "********",
+
+  "field.label.new-password": "புதிய கடவுச்சொல்",
+  "field.placeholder.new-password": "********",
+
+  "link.create-account": "கணக்கை துவங்குங்கள்",
+  "link.forgot-password": "கடவுச்சொல்லை மறந்துவிட்டீர்களா?",
+  "link.login": "கணக்கு உள்ளதா? உள்நுழைய",
+  "link.login-minimal": "உள்நுழைய"
+}


### PR DESCRIPTION
Hi there!

First of all, thank you for sharing this amazing project and code to all of us, including `nitrogen`  repo.

I would like to contribute back a bit to your project by adding a simple `spanish` translation, as it is my mother tongue.

Besides that, I was playing around with your code and found that `/not-found` route was being handled by `express` instead of `react` through the sample `static site ui`. For that reason, I debugged a bit and found that `/not-found` route was missing inside the `backend` or `service`  code.

I updated that piece of code and translated the hardcoded message on `/not-found` component. 

Please, consider the translations I have added (new key `message.page-not-found`) under `ta` and `fr` languages as examples. I translated from english to those languages using Google Translate.

Hope you find this useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new route for handling "Page Not Found" scenarios.
	- Introduced localization for user authentication system in Spanish and updates in other languages.

- **Bug Fixes**
	- Corrected typo in error message keys across multiple language files.
	- Enhanced error message handling in the `Login` and `GetCode` components.

- **Documentation**
	- Updated error and informational messages in English, French, and Tamil to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->