### PR TITLE
Update `error.duplicate-username` message on `es` and `fr` languages

### DIFF
--- a/src/public/languages/es.json
+++ b/src/public/languages/es.json
@@ -23,7 +23,7 @@
   "error.invalid-login": "Inicio de sesión inválido",
   "error.bad-email-domain": "Dominio de e-mail erróneo",
   "error.duplicate-account": "La cuenta ya existe",
-  "error.duplicate-username": "Username is already taken",
+  "error.duplicate-username": "El nombre de usuario no está disponible",
   "error.signup-error": "Error en el registro",
   "error.invalid-field": "{{field_name}} inválido/a",
   "error.invalid-code": "Código inválido",

--- a/src/public/languages/fr.json
+++ b/src/public/languages/fr.json
@@ -23,7 +23,7 @@
   "error.invalid-login": "Identifiant invalide",
   "error.bad-email-domain": "Mauvais domaine de messagerie",
   "error.duplicate-account": "Le compte existe déjà",
-  "error.duplicate-username": "Username is already taken",
+  "error.duplicate-username": "Le username n'est pas disponible",
   "error.signup-error": "Erreur d'inscription",
   "error.invalid-field": "{{field_name}} invalide",
   "error.invalid-code": "Code invalide",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Improved clarity of error messages for duplicate usernames in Spanish and French translations.
    - Spanish: "El nombre de usuario no está disponible"
    - French: "Le username n'est pas disponible"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->